### PR TITLE
Refactored alignment into its own module.

### DIFF
--- a/pyprot/alignment.py
+++ b/pyprot/alignment.py
@@ -19,10 +19,11 @@ def get_alignment(sequenceA, sequenceB, featuresA, featuresB):
     Returns
     -------
     featureA: element of featuresA aligned with element of featuresB
-    featureB: element of featuresB aligned with element of featuresA 
+    featureB: element of featuresB aligned with element of featuresA
     """
     alignment = max(pairwise2.align.globalxx(sequenceA, sequenceB), key=operator.itemgetter(1))
-    alignedA, alignedB, _, _, _ = alignment
+    alignedA, alignedB, _, __, ___ = alignment
+
 
     featuresA = iter(featuresA)
     featuresB = iter(featuresB)
@@ -65,7 +66,9 @@ def join_conservation_data(sequence, features_dict, conservation_file):
     for res_id, line in get_alignment(sequence, cons_sequence, features, lines):
         features_dict[res_id]["score"] = float(line[3])
         features_dict[res_id]["color"] = line[5]
-        features_dict[res_id]["score_confidence_interval"] = line[6]
-        features_dict[res_id]["color_confidence_interval"] = line[9]
-        features_dict[res_id]["residue_variety"] = line[-1]
+        features_dict[res_id]["score_confidence_interval_low"] = float(line[6].split(",")[0])
+        features_dict[res_id]["score_confidence_interval_high"] = float(line[6].split(",")[1])
+        features_dict[res_id]["color_confidence_interval_low"] = float(line[9].split(",")[0])
+        features_dict[res_id]["color_confidence_interval_high"] = float(line[9].split(",")[1])
+        features_dict[res_id]["residue_variety"] = line[-1].replace(",", " ")
     return features_dict


### PR DESCRIPTION
Uncoupled the alignment operation and from the conservation data join. Hopefully in the future it can be used for other things to add features in the dataframe.

the old read_conservation() has been split into four functions:
* alignment.get_alignment 
  + it is a generator that yields aligned features
* alignment.join_conservation_data
  + reads the conservation file and maps residue ids to conservation features
* protein.Protein.get_conservation_features
  + runs join_conservation_data for each chain sequence and merges results
* protein.Protein.add_residue_features
  + joins a dictionary mapping residue ids to features with the dataframe


Example usage:
```
p = protein.Protein("6std.pdb")
features = p.get_conservation_features("consurf6std", None)
p.add_residue_features(features)
p.df.head()
```
6std.pdb => https://files.rcsb.org/download/6STD.pdb
consurf6std => http://bental.tau.ac.il/new_ConSurfDB/DB/6STD/A/consurf.grades


Also fixes #3 