### PR TITLE
Features propagation

### DIFF
--- a/pyprot/graph_models.py
+++ b/pyprot/graph_models.py
@@ -1,4 +1,5 @@
 import networkx as nx
+import pandas as pd
 from itertools import combinations
 from getcontacts.contact_calc.compute_contacts import compute_contacts
 from getcontacts.contact_calc import transformations
@@ -15,6 +16,10 @@ class GraphModel:
         raise NotImplementedError
     def add_features(self, dataframe, columns):
         raise NotImplementedError
+    @staticmethod
+    def graph_to_dataframe(G):
+        return pd.DataFrame.from_dict({node_idx: {feature: val for feature,val in G.nodes[node_idx].items()}
+              for node_idx in G.nodes}, orient="index")
     def get_diffused_graph(self, aggregator = None, keys = None, steps = 1):
         """Diffuses some `keys` features across graph neighbors that are
         `steps` apart and afterwards process the groups using `aggregator`.


### PR DESCRIPTION
[please merge PR #11 before! I'll need to rebase this branch before we can merge it into master]

* StaticContactGraphGenerator, StructureGraphGenerator now inherit from GraphModel
* GraphModel can propagate features!

The propagation function (GraphModel.get_diffused_graph) has three things in mind:
* the user may want to select *some* features but not all
* how to aggregate the data may be defined by the user (maybe they want a _mean, _max, _min, maybe they want to also handle non-numerical data, etc.)
* and the amount of neighbors to propagate to is of course variable

The default behavior is to use all features and mean() them where applicable.

Example usage (setup the protein using the code in PR #6):
```python
# Setup
contact_model = graph_models.StaticContactGraphGenerator()
graph = p.generate_graph(contact_model, {})
contact_model.add_features(p.df)
# -----
# Actual usage
G = contact_model.get_diffused_graph()
G.nodes['A:GLU:155']
```
Should output:
```
{'bfactor_1': 19.795794507575756,
 'score_1': -0.6616249999999999,
 'color_confidence_interval_high_1': 7.0,
 'color_confidence_interval_low_1': 7.75,
 'score_confidence_interval_high_1': -0.5438750000000001,
 'score_confidence_interval_low_1': -0.92275,
 'bfactor': 22.487777777777776,
 'score': -1.252,
 'color_confidence_interval_high': 9.0,
 'color_confidence_interval_low': 9.0,
 'score_confidence_interval_high': -1.187,
 'score_confidence_interval_low': -1.4079999999999997}
```

I considered returning a dataframe instead of a graph, but that sounds like too much responsibility for one function! So maybe we can add later a function that does just that.