### PR TITLE
Discard chains and ligand molecules.

### DIFF
--- a/pyprot/protein.py
+++ b/pyprot/protein.py
@@ -361,3 +361,15 @@ class Protein:
             df["x"], df["y"], df["z"] = zip(*df.coord.apply(
                 lambda x: self.__get_coordinates(x, raise_error)))
         self._df = df
+
+    def select_chains(self, chain_list):
+        """Discards rows from the dataframe that are not in the chainlist."""
+        self.df = self.df[self.df.chain.isin(chain_list)]
+
+    def discard_ligands(self):
+        """Discards rows from the dataframe that correspond to ligands or
+        heterogen atoms.
+        For more information read about the HET section in PDB files."""
+        het_rows = self.df.res_full_id.apply(
+            lambda res: res[3][0] == "W" or res[3][0][0:2] == "H_")
+        self.df = self.df.loc[~het_rows]


### PR DESCRIPTION
Please merge #6 first.
Fixes #12.
Fixes #7.
Based  on the PDB format's documentation about the [HET section](http://www.wwpdb.org/documentation/file-format-content/format33/v3.3.html) and BioPython's [handling](https://biopython.org/wiki/The_Biopython_Structural_Bioinformatics_FAQ) of heterogenous molecules we can discard atoms that are not part of the biological polymer described in SEQRES.

This is of course optional and is provided as a function. 

Example usage:

```python
p.df.tail() #Usually HETATM (water molecules etc) end up at the end of the dataframe.
p.discard_ligands()
p.df.tail() #They should no longer appear.
```

Also I added a new function that keeps only some chains (`Protein.select_chains([list])`)